### PR TITLE
Add type for energy counters (8378, 8379, 8380)

### DIFF
--- a/BSB_lan.ino
+++ b/BSB_lan.ino
@@ -1652,6 +1652,7 @@ char *printTelegram(byte* msg, int query_line) {
               break;
             case VT_POWER: // u32 / 10.0 kW
             case VT_ENERGY: // u32 / 10.0 kWh
+            case VT_ENERGY_1: // u32 / 1.0 kWh
               printFIXPOINT_DWORD(msg,data_len,div_operand,div_precision,div_unit);
               break;
             case VT_ONOFF:

--- a/BSB_lan_defs.h
+++ b/BSB_lan_defs.h
@@ -199,6 +199,7 @@ typedef enum{
   VT_MINUTES,           //  5 Byte - 1 enable 0x01 / seconds/60
   VT_POWER,             //  5 Byte - 1 enable / value/10 kW
   VT_ENERGY,            //  5 Byte - 1 enable / value/10 kWh
+  VT_ENERGY_1,          //  5 Byte - 1 enable / value/1 kWh
   VT_DATETIME,          //* 9 Byte - 1 enable 0x01 / year+1900 month day weekday hour min sec
   VT_SUMMERPERIOD,      //* 9 Byte - no flag? 1 enable / byte 2/3 month/year
   VT_VACATIONPROG,      //* 9 Byte - 1 enable 0x06 / byte 2/3 month/year
@@ -316,6 +317,7 @@ PROGMEM_LATE const units optbl[]={
 {VT_MINUTES,        60.0,   DT_VALS, 0,  U_MIN, sizeof(U_MIN)},
 {VT_POWER,          10.0,   DT_VALS, 1,  U_KW, sizeof(U_KW)},
 {VT_ENERGY,         10.0,   DT_VALS, 1,  U_KWH, sizeof(U_KWH)},
+{VT_ENERGY_1,       1.0,    DT_VALS, 0,  U_KWH, sizeof(U_KWH)},
 {VT_DATETIME,       1.0,    DT_DTTM, 0,  U_NONE, sizeof(U_NONE)},
 {VT_SUMMERPERIOD,   1.0,    DT_DDMM, 0,  U_NONE, sizeof(U_NONE)},
 {VT_VACATIONPROG,   1.0,    DT_DDMM, 0,  U_NONE, sizeof(U_NONE)},
@@ -5419,9 +5421,9 @@ PROGMEM_LATE const cmd_t cmdtbl[]={
 {0x053D2FEC,  CAT_DIAG_ERZEUGER,    VT_HOURS,         8339,  STR8339,  0,                    NULL,         FL_RONLY,     DEV_163_ALL}, // WGBS Betriebsstunden TWW
 {0x193D2FEC,  CAT_DIAG_ERZEUGER,    VT_HOURS,         8339,  STR8339,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Thision Betriebsstunden TWW
 {0x193D2FED,  CAT_DIAG_ERZEUGER,    VT_HOURS,         8340,  STR8340,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Thision Betriebsstunden Zonen
-{0x053D1A7A,  CAT_DIAG_ERZEUGER,    VT_UNKNOWN,       8378,  STR8378,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gesamt Gasenergie Heizen
-{0x053D1A7B,  CAT_DIAG_ERZEUGER,    VT_UNKNOWN,       8379,  STR8379,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gesamt Gasenergie Trinkwasser
-{0x053D1A7C,  CAT_DIAG_ERZEUGER,    VT_UNKNOWN,       8380,  STR8380,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gesamt Gasenergie
+{0x053D1A7A,  CAT_DIAG_ERZEUGER,    VT_ENERGY_1,      8378,  STR8378,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gesamt Gasenergie Heizen
+{0x053D1A7B,  CAT_DIAG_ERZEUGER,    VT_ENERGY_1,      8379,  STR8379,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gesamt Gasenergie Trinkwasser
+{0x053D1A7C,  CAT_DIAG_ERZEUGER,    VT_ENERGY_1,      8380,  STR8380,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gesamt Gasenergie
 {0x053D1A7D,  CAT_DIAG_ERZEUGER,    VT_UNKNOWN,       8381,  STR8381,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gasenergie Heizen Reset
 {0x053D1A7E,  CAT_DIAG_ERZEUGER,    VT_UNKNOWN,       8382,  STR8382,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gasenergie Trinkwasser Reset
 {0x053D1A7F,  CAT_DIAG_ERZEUGER,    VT_UNKNOWN,       8383,  STR8383,  0,                    NULL,         FL_RONLY,     DEV_ALL}, // Gasenergie Reset


### PR DESCRIPTION
After finally getting my board assembled, I am now using this project with our Brötje WGB Evo 20 H. Most parts are working great!
Among the values not yet readable were the energy counters 8378, 8379, and 8380, which were still configured as VT_UNKNOWN. The attached patch reads them correctly. Please let me know if you see any issues with this change that need to be fixed before adding them to the official code base. Thanks.