### PR TITLE
Update BSB_lan.ino

### DIFF
--- a/BSB_lan.ino
+++ b/BSB_lan.ino
@@ -419,7 +419,7 @@ char buffer[BUFLEN] = { 0 };
 char outBuf[OUTBUF_LEN] = { 0 };
 byte outBufLen=0;
 
-char div_unit[10];
+char div_unit[32];
 
 #ifdef WIFI
 WiFiEspClient client;


### PR DESCRIPTION
I found the cause of the problems going on with me. Everything turned out to be trivial: the size of the dev_unit variable is not enough to store language-independent unit identifiers.