### PR TITLE
Added a surrounding '#ifdef LOGGER' for 'printTrailToFile()' as other…

### DIFF
--- a/BSB_lan.ino
+++ b/BSB_lan.ino
@@ -2762,12 +2762,14 @@ char *GetDateTime(char date[]){
  * Global resources used:
  *
  * *************************************************************** */
+#ifdef LOGGER
 void printTrailToFile(File *dataFile){
  char fileBuf[64];
  // get current time from heating system
  sprintf(fileBuf, "%lu;%s;", millis(), GetDateTime(date));
  dataFile->print(fileBuf);
 }
+#endif
 
 /** *****************************************************************
  *  Function:  LogTelegram()


### PR DESCRIPTION
…wise the compiler stops with an error (if 'LOGGER' is not defined):

```
BSB_lan:2765:23: error: variable or field 'printTrailToFile' declared void
 void printTrailToFile(File *dataFile){
                       ^~~~
BSB_lan:2765:23: error: 'File' was not declared in this scope
BSB_lan:2765:29: error: 'dataFile' was not declared in this scope
 void printTrailToFile(File *dataFile){
                             ^~~~~~~~
```

This is also done in front of the function "void LogTelegram(byte* msg)", so I hope that just adding this #ifdef is enough and I have not missed anything else.