### PR TITLE
use 192.168.178 subnet in default mqtt config

### DIFF
--- a/BSB_lan_config.h.default
+++ b/BSB_lan_config.h.default
@@ -138,7 +138,7 @@ int log_parameters[40] = {
 //#define MQTT
 byte mqtt_mode = 0; //MQTT: 0 - disabled, 1 - send messages in plain text format, 2 - send messages in JSON format. Use this if you want a json package of your logging information printed to the mqtt topic
 // JSON payload will be of the structure: {"MQTTDeviceID": {"status":{"log_param1":"value1","log_param2":"value2"}, ...}}
-byte mqtt_broker_ip_addr[4] = {192,168,1,20};// Please use commas instead of dots!!!
+byte mqtt_broker_ip_addr[4] = {192,168,178,20};// Please use commas instead of dots!!!
 char MQTTUsername[32] = "User"; // Set username for MQTT broker here or set zero-length string if no username/password is used.
 char MQTTPassword[32] = "Pass"; // Set password for MQTT broker here or set zero-length string if no password is used.
 char MQTTTopicPrefix[32] = "BSB-LAN"; 	// Optional: Choose the "topic" for MQTT messages here. If zero-length string here, default topic name used


### PR DESCRIPTION
I guess it makes sense to use the same subnet as default here as you do for all other network config defaults?