### PR TITLE
Enhanced software-controlled writing values to programs

### DIFF
--- a/BSB_lan_EEPROMconfig.h
+++ b/BSB_lan_EEPROMconfig.h
@@ -37,7 +37,7 @@ typedef enum{
   CF_IPWEVALUESLIST, //Size 2 * 40 bytes. Array of prognrs 1-65535. prognr 0 will be ignored
   CF_MAX, //Size: 1 byte. Enable CUNO/CUNX/modified MAX!Cube
   CF_MAX_IPADDRESS, //Size: 4 bytes. IP v4 address of CUNO/CUNX/modified MAX!Cube.
-  CF_READONLY, //Size: 1 byte. All parameters will be FL_RONLY
+  CF_WRITEMODE, //Size: 1 byte. 0 - all parameters will be FL_RONLY, 1 - write ordinary programs, 2 - write OEM programs
   CF_DEBUG, //Size: 1 byte. Debug: 0 - disabled, 1 - debug to serial interface, 2 - debug to telnet
   CF_MQTT, //Size: 1 byte. MQTT: 0 - disabled, 1 - enabled, plain text, 2 - enabled, JSON
   CF_MQTT_IPADDRESS, //Size: 4 bytes. MQTT broker IP v4 address
@@ -150,7 +150,7 @@ PROGMEM_LATE const configuration_struct config[]={
   {CF_PPS_VALUES,       0, CCAT_GENERAL,  CPI_NOTHING,   CDT_VOID,           NULL, sizeof(pps_values[PPS_TWS]) * (PPS_BRS - PPS_TWS + 1)}, //printlnToDebug(PSTR("Reading EEPROM..."));  for (int i=PPS_TWS;i<=PPS_BRS;i++){ ...}
 #ifdef CONFIG_IN_EEPROM
 #ifdef WEBCONFIG
-  {CF_READONLY,         2, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           CF_READONLY_TXT, sizeof(readOnlyMode)},
+  {CF_WRITEMODE,        2, CCAT_GENERAL,  CPI_DROPDOWN,  CDT_BYTE,           CF_WRITEMODE_TXT, sizeof(programWriteMode)},
   {CF_DEBUG,            2, CCAT_GENERAL,  CPI_DROPDOWN,  CDT_BYTE,           CF_DEBUG_TXT, sizeof(debug_mode)},
   {CF_VERBOSE,          3, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           CF_VERBOSE_TXT, sizeof(verbose)},
   {CF_MONITOR,          3, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           CF_MONITOR_TXT, sizeof(monitor)},

--- a/BSB_lan_defs.h
+++ b/BSB_lan_defs.h
@@ -653,7 +653,7 @@ const char CF_IPWE_TXT[] PROGMEM = CF_IPWE_TEXT;
 const char CF_IPWEVALUESLIST_TXT[] PROGMEM = CF_IPWEVALUESLIST_TEXT;
 const char CF_MAX_TXT[] PROGMEM = CF_MAX_TEXT;
 const char CF_MAX_IPADDRESS_TXT[] PROGMEM = CF_MAX_IPADDRESS_TEXT;
-const char CF_READONLY_TXT[] PROGMEM = CF_READONLY_TEXT;
+const char CF_WRITEMODE_TXT[] PROGMEM = CF_WRITEMODE_TEXT;
 const char CF_DEBUG_TXT[] PROGMEM = CF_DEBUG_TEXT;
 const char CF_VERBOSE_TXT[] PROGMEM = MENU_TEXT_VBL;
 const char CF_MONITOR_TXT[] PROGMEM = MENU_TEXT_MMD;
@@ -6494,6 +6494,11 @@ const char ENUM_MQTT[] PROGMEM_LATEST = {
 "\x03 " ENUM_MQTT_JSON2_TEXT
 };
 
+const char ENUM_WRITEMODE[] PROGMEM_LATEST = {
+"\x00 " MENU_TEXT_OFF "\0"
+"\x01 " ENUM_WRITE_ENG_TEXT "\0"
+"\x02 " ENUM_WRITE_OEM_TEXT
+};
 //Choices for YES/NO, ON/OFF, CLOSED/OPEN, voltage ON/OFF
 const char ENUM_ONOFF[] PROGMEM_LATEST = {
 "\x00 " MENU_TEXT_OFF "\0"
@@ -11311,7 +11316,8 @@ PROGMEM_LATE const cmd_t cmdtbl2[]={
 };
 
 PROGMEM_LATE const cmd_t cmdtbl3[]={
-  //Prognr 65529 - 65534 is a dirty trick for reducing enumerations addresses to the same type
+  //Prognr 65528 - 65534 is a dirty trick for reducing enumerations addresses to the same type
+{0xDEADBEEF,  CAT_UNKNOWN,          VT_ENUM,          65528, "",       sizeof(ENUM_WRITEMODE),   ENUM_WRITEMODE,         DEFAULT_FLAG, DEV_ALL}, //
 {0xDEADBEEF,  CAT_UNKNOWN,          VT_ENUM,          65529, "",       sizeof(ENUM_MQTT),   ENUM_MQTT,         DEFAULT_FLAG, DEV_ALL}, //
 {0xDEADBEEF,  CAT_UNKNOWN,          VT_ENUM,          65530, "",       sizeof(ENUM_DEBUG),   ENUM_DEBUG,         DEFAULT_FLAG, DEV_ALL}, //
 {0xDEADBEEF,  CAT_UNKNOWN,          VT_ENUM,          65531, "",       sizeof(ENUM_LOGTELEGRAM),   ENUM_LOGTELEGRAM,         DEFAULT_FLAG, DEV_ALL}, //

--- a/localization/LANG_DE.h
+++ b/localization/LANG_DE.h
@@ -196,7 +196,7 @@
 #define CF_IPWEVALUESLIST_TEXT "Programs for displaying with IPWE"
 #define CF_MAX_TEXT "Enable MAX"
 #define CF_MAX_IPADDRESS_TEXT "CUNO/CUNX/modified MAX!Cube IP address"
-#define CF_READONLY_TEXT "All parameters is read only"
+#define CF_WRITEMODE_TEXT "Write parameters to system"
 #define CF_DEBUG_TEXT "Debug"
 #define CF_MQTT_TEXT "Using MQTT"
 #define CF_MQTT_IPADDRESS_TEXT "MQTT broker IP address"
@@ -1986,6 +1986,9 @@
 #define ENUM_MQTT_PLAIN_TEXT "Plain text"
 #define ENUM_MQTT_JSON_TEXT "JSON"
 #define ENUM_MQTT_JSON2_TEXT "Rich JSON"
+
+#define ENUM_WRITE_ENG_TEXT "Ein (Engineer)"
+#define ENUM_WRITE_OEM_TEXT "Ein (Engineer + OEM)"
 
 #define ENUM20_01_TEXT "English"
 #define ENUM20_02_TEXT "Deutsch"

--- a/localization/LANG_RU.h
+++ b/localization/LANG_RU.h
@@ -204,7 +204,7 @@
 #define CF_IPWEVALUESLIST_TEXT "Значения программ, отображаемых через IPWE"
 #define CF_MAX_TEXT "Использовать MAX!"
 #define CF_MAX_IPADDRESS_TEXT "IP-адрес устройства CUNO/CUNX/мод. MAX!Cube"
-#define CF_READONLY_TEXT "Все параметры только для чтения"
+#define CF_WRITEMODE_TEXT "Запись параметров в систему"
 #define CF_DEBUG_TEXT "Отладка"
 #define CF_MQTT_TEXT "Использовать MQTT"
 #define CF_MQTT_IPADDRESS_TEXT "IP-адрес брокера MQTT"
@@ -1720,6 +1720,9 @@
 #define ENUM_MQTT_PLAIN_TEXT "Обычный текст"
 #define ENUM_MQTT_JSON_TEXT "JSON"
 #define ENUM_MQTT_JSON2_TEXT "Подробный JSON"
+
+#define ENUM_WRITE_ENG_TEXT "Вкл. (Инженерные)"
+#define ENUM_WRITE_OEM_TEXT "Вкл. (Инженерные + OEM)"
 
 #define ENUM20_01_TEXT "Английский"
 #define ENUM20_02_TEXT "Немецкий"


### PR DESCRIPTION
Now is three states here:
0 - all programs is read-only.
1 - all programs is writable except read-only and OEM
2 - all programs is writable except read-only

WARNING: "read-only" behavior is inverted after upgrade. Check setting.