### PR TITLE
Update BSB_lan.ino

### DIFF
--- a/BSB_lan.ino
+++ b/BSB_lan.ino
@@ -4232,10 +4232,10 @@ int set(int line      // the ProgNr of the heater parameter
       for (int x=payload_length;x>0;x--) {
         param[payload_length-x+1] = (t >> ((x-1)*8)) & 0xff;
       }
-      if(val[0]!='\0'){
-        param[0]=enable_byte;  //enable
-      }else{
+      if(val[0] == '\0' || (type == VT_ENUM && t == 0xFFFF)){
         param[0]=enable_byte-1;  // disable
+      }else{
+        param[0]=enable_byte;  //enable
       }
       param_len=payload_length + 1;
       }


### PR DESCRIPTION
set(): implement "disable" for ENUMs.

@fredlcore i concerned with this fragment:
```
      if (val[0] == '-') {
        t=((int)(atof(val)*operand));
      } else {
        t=atoi(val)*operand;
      }
```
if val is positive then atoi() cut fractional part. Can you check it?