### PR TITLE
JSON API version

### DIFF
--- a/BSB_lan.ino
+++ b/BSB_lan.ino
@@ -7329,7 +7329,7 @@ uint8_t pps_offset = 0;
           }
 
           if (p[2] == 'V'){ // JSON API version
-            printFmtToWebClient(PSTR("{\"api_version\": \"" JSON_MAJOR "." JSON_MINOR "\"}"));
+            printFmtToWebClient(PSTR("\"api_version\": \"" JSON_MAJOR "." JSON_MINOR "\"\r\n}"));
             forcedflushToWebClient();
             break;
           }

--- a/json-api-version.h
+++ b/json-api-version.h
@@ -1,0 +1,2 @@
+#define JSON_MAJOR "2"
+#define JSON_MINOR "0"


### PR DESCRIPTION
/JV comamnd for JSON API version added. Payload: {"api_version": "major.minor"}
strncasecmp() replaced with strncmp_P()
New file added: json-api-version.h