### PR TITLE
Fix MDNS_HOSTNAME undefine

### DIFF
--- a/BSB_lan_config.h.default
+++ b/BSB_lan_config.h.default
@@ -307,7 +307,7 @@ uint32_t destinationDelay = 84600;  // interval in seconds to send values
 #undef DEBUG
 #undef IPWE
 #undef MQTT
-#undef MDNS_HOST
+#undef MDNS_HOSTNAME
 #undef OFF_SITE_LOGGER
 #undef ROOM_UNIT
 #undef VERSION_CHECK


### PR DESCRIPTION
It was added recently, but undefine referring to wrong define meant that MDNS still took space on Mega2560 by default.

With custom defs optimization and this change there was enough space to also fit MQTT in my case without changing anything else - good result.