### PR TITLE
Update LANG_FR.h

### DIFF
--- a/BSB_LAN/localization/LANG_FR.h
+++ b/BSB_LAN/localization/LANG_FR.h
@@ -7,7 +7,7 @@
 #define MENU_TEXT_SN2 "Capteurs DHT22"
 #define MENU_TEXT_CHK "Liste des paramètres spécifiques à l'appareil"
 #define MENU_TEXT_DLG "Afficher le fichier journal"
-#define MENU_TEXT_SLG "Enregistrer le fichier journal"
+#define MENU_TEXT_SLG "Fichier journal du tracé"
 #define MENU_TEXT_CFG "Paramètres"
 #define MENU_TEXT_URL "Commandes URL"
 #define MENU_TEXT_HWT "Guide d’utilisation"


### PR DESCRIPTION
#define MENU_TEXT_BRS "La durée du four et de l'eau chaude est mise à zéro" // The previous translation was incorrect – this line indicates that the oven and hot water durations are reset to zero.

#define MENU_TEXT_VBL "Mode verbosité" // Suggested: "Affichage détaillé" – this is clearer for users, as it describes the purpose of the setting (displaying detailed information) rather than using the more technical term "verbosité".

#define MENU_TEXT_VB1 "Mode verbeux activé !" // Suggested: "Affichage détaillé activé !" – this is more commonly used in user interfaces, and "affichage détaillé" better conveys the idea of verbose output in plain language.

#define MENU_TEXT_VB2 "Mode verbeux désactivé !" // Suggested: "Affichage détaillé désactivé !" – maintains consistency with VB1, and is more user-friendly than "verbeux", which can sound pejorative or overly technical.

#define MENU_TEXT_HWT "Comment faire" // Suggested: "Guide d’utilisation" – "Comment faire" is vague; "Guide d’utilisation" is more standard in user-facing texts and clearly refers to instructions or help documentation.

#define MENU_TEXT_SLG "Fichier journal du tracé" // Suggested: "Enregistrer le fichier journal" – the original is overly technical and unclear; the suggestion is more direct and action-oriented, indicating the purpose of the menu item.

Moreover, I have added the translation of the terms present in LANG_DE that were not included in the French version. I hope I did things correctly this time.