### PR TITLE
Esp32 lib bug workaround for /DG etc.

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -6942,7 +6942,6 @@ next_parameter:
                 //   because we really don't expect this to fail here, and we wouldn't
                 //   know how to meaningfully deal with it if it did, anyway.
                 long currentDatalogPosition = dataFile.size();
-                printFmtToDebug("currentDatalogPosition=%ld\r\n",currentDatalogPosition);
                 indexFile.write((byte*)&currentDate, sizeof(currentDate));
                 indexFile.write((byte*)&currentDatalogPosition, sizeof(currentDatalogPosition));
                 if (!firstDatalogDate.combined) firstDatalogDate.combined = currentDate.combined;


### PR DESCRIPTION
One of the esp32's libraries currently has a bug that breaks /DG (and some other /D...'s) functionality.
This PR presents a workaround. See comments in the code and commits below.

Please note: As I have an esp32 NodeMcu only, I haven't been able to test the change on other bsb-lan configurations.