### PR TITLE
simple dark mode

### DIFF
--- a/BSB_LAN/BSB_LAN_config.h.default
+++ b/BSB_LAN/BSB_LAN_config.h.default
@@ -15,6 +15,9 @@
 */
 #define LANG DE
 
+// enable this definition for muted white on black HTML pages:
+//#define SIMPLE_DARK_MODE
+
 /*
 Allow to initialize program configuration by reading settings from EEPROM
 byte UseEEPROM = 0; // Configuration is read from this config file.

--- a/BSB_LAN/html_strings.h
+++ b/BSB_LAN/html_strings.h
@@ -441,7 +441,11 @@ const char header_html2[] =
       "if(x.options[i].selected)" NEWLINE
         "v=v+eval(x.options[i].value);" NEWLINE
     "window.open(document.getElementById('main_link').href+'S'+p+'='+v,'_self')" NEWLINE
-  "}</script>";
+  "}" NEWLINE
+#ifdef SIMPLE_DARK_MODE
+  "document.documentElement.style.filter='invert(95%)hue-rotate(180deg)'" NEWLINE
+#endif
+  "</script>";
 const char header_html3[] =
   "<font face='Arial'>"
   "<center>";


### PR DESCRIPTION
...for muted white on black HTML pages, which some users might prefer.
Must be explicitly enabled in BSB_LAN_config.h

Works by inverting page colors (by 95%, because pure black background doesn't look as good), then reverting hues.
Unfortunately, there seems to be no easy way to keep the colors' original saturation. This makes for a somewhat "muted" look, which _might_ be considered appropriate for a dark mode.

original:
<img width="644" height="517" alt="Bildschirmfoto vom 2025-11-11 09-00-15" src="https://github.com/user-attachments/assets/bb326e69-87cb-468e-9d78-f871fcabe38e" />
<img width="644" height="517" alt="Bildschirmfoto vom 2025-11-11 09-02-36" src="https://github.com/user-attachments/assets/a9cb8d0f-599c-4a0b-ab99-963fb8fd5d85" />

with SIMPLE_DARK_MODE defined:
<img width="644" height="517" alt="Bildschirmfoto vom 2025-11-11 08-58-04" src="https://github.com/user-attachments/assets/038e0af3-c70d-4157-b6bf-56a701d4643f" />
<img width="644" height="517" alt="Bildschirmfoto vom 2025-11-11 08-58-42" src="https://github.com/user-attachments/assets/964b4815-1f93-4baf-a020-d8eb8fe3202e" />

